### PR TITLE
Updates ansible-core 2.18.8-1 release

### DIFF
--- a/vars.json
+++ b/vars.json
@@ -1,5 +1,5 @@
 {
-    "ansible-core-version": "2.18.7",
+    "ansible-core-version": "2.18.8",
     "fedora-version": "42",
     "ansible.posix": "1.6.2",
     "ansible.utils": "5.1.2",


### PR DESCRIPTION
Edits the `ansible-core` version to 2.18.8 for  `community ee base` and `community-ee-minimal`  version 2.18.8-1, release. 