### PR TITLE
Updates fedora version to 42 & core 2.19.4

### DIFF
--- a/vars.json
+++ b/vars.json
@@ -1,6 +1,6 @@
 {
-    "ansible-core-version": "2.19.3",
-    "fedora-version": "42",
+    "ansible-core-version": "2.19.4",
+    "fedora-version": "43",
     "ansible.posix": "2.1.0",
     "ansible.utils": "6.0.0",
     "ansible.windows": "3.2.0"


### PR DESCRIPTION
Updates fedora and ansible core for ee 2.19.4-1 version release : 

- fedora version to 42 

- ansible-core version to  2.19.4