### PR TITLE
Deals with both 2.19 and newer releases

### DIFF
--- a/alltests.py
+++ b/alltests.py
@@ -57,7 +57,12 @@ class eertest(unittest.TestCase):
             self.assertIn(data['ansible.utils'], out_dict["/usr/share/ansible/collections/ansible_collections"]["ansible.utils"]["version"])
             self.assertIn(data['ansible.windows'], out_dict["/usr/share/ansible/collections/ansible_collections"]["ansible.windows"]["version"])
         else:
-            self.assertIsNot(eid,0)
+            # Only in 2.19 series of releases we have `ansible._protomatter`
+            # In other releases there is no collection in the minimal image
+            if os.environ.get("IMAGE_ANSIBLE_VERSION") == "2.19":
+                self.assertEqual(eid,0)
+            else:
+                self.assertIsNot(eid,0)
 
 if __name__ == "__main__":
     status_code = unittest.main()

--- a/containertest.py
+++ b/containertest.py
@@ -51,6 +51,11 @@ def main():
         else:
             type_of_image = 'base'
         print(f"Starting container image {image.tags[0]}.")
+        version = image.tags[0].split(":")[1]
+        if version.startswith("2.19"):
+            image_ansible_version = "2.19"
+        else:
+            image_ansible_version = version[0:4]
         container = client.containers.run(
             image,
             "/usr/bin/bash",
@@ -59,7 +64,7 @@ def main():
             tty=True,
             mounts=volume,
             remove=True,
-            environment={"IMAGENAME": type_of_image},
+            environment={"IMAGENAME": type_of_image, "IMAGE_ANSIBLE_VERSION": image_ansible_version},
         )
         code, output = container.exec_run("/usr/bin/python3 /runner/alltests.py")
         print(output.decode("utf-8", errors="ignore"))

--- a/containertest.py
+++ b/containertest.py
@@ -52,10 +52,7 @@ def main():
             type_of_image = 'base'
         print(f"Starting container image {image.tags[0]}.")
         version = image.tags[0].split(":")[1]
-        if version.startswith("2.19"):
-            image_ansible_version = "2.19"
-        else:
-            image_ansible_version = version[0:4]
+        image_ansible_version = ".".join(version.split(".")[:2])
         container = client.containers.run(
             image,
             "/usr/bin/bash",


### PR DESCRIPTION
Only the 2.19 ee-minimal image series consists of `ansible._protomatter` collections, 2.20 series does not. This PR makes two different version of test case depending upon which version images we are testing.